### PR TITLE
Add Dockerfile and allow cors streaming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Use their image that contains all the necessary libraries & headers
+# to compile the srs application
+FROM ossrs/dev 
+
+# Create our app directory
+RUN mkdir /app
+
+WORKDIR /app
+
+ADD trunk /app
+
+# Compile the srs application that we forked
+RUN ./configure && make
+
+# Run SRS using the http flv streaming config
+CMD ./objs/srs -c conf/http.flv.live.conf

--- a/trunk/src/app/srs_app_http_stream.cpp
+++ b/trunk/src/app/srs_app_http_stream.cpp
@@ -502,6 +502,7 @@ int SrsLiveStream::do_serve_http(ISrsHttpResponseWriter* w, ISrsHttpMessage* r)
     srs_assert(entry);
     if (srs_string_ends_with(entry->pattern, ".flv")) {
         w->header()->set_content_type("video/x-flv");
+        w->header()->set("Access-Control-Allow-Origin", "*"); 
 #ifdef SRS_PERF_FAST_FLV_ENCODER
         bool realtime = _srs_config->get_realtime_enabled(req->vhost);
         if (realtime) {


### PR DESCRIPTION
Contents on this PR:
- Update code for http stream to allow CORS headers to allow our video to be played on the web
- Add a dockerfile  that compiles everything and run the server with the correct config

@vlasbaard I've forked this code into fuga. Do you know why I can't request review from joost and clement?